### PR TITLE
Remove num_decks argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ bankroll.
 `insurance_func` should be a function that will determine if a player takes
 insurance when the dealer is showing an ace. It must return `True` or `False`.
 
-The `Game` class has two required arguments and two optional ones. `num_decks`
-is an integer for the number of decks used in the game, `players` is a list of
-instances of the `Players` class that will be used in the game. `rules` can be
-a dictionary containing changes to the game's default rules to run the simulation
-under different scenarios. An explanation of how the dictionary should be
-structured is below. Finally, `verbose` is a boolean indicator for whether or
-not you want information printed out as the game is played.
+The `Game` class has one required argument and two optional ones. `players`
+is a list of instances of the `Players` class that will be used in the game.
+`rules` can be a dictionary containing changes to the game's default rules to
+run the simulation under different scenarios. An explanation of how the
+dictionary should be structured is below. Finally, `verbose` is a boolean
+indicator for whether or not you want information printed out as the game is
+played.
 
 Running a simulation can be done in a few lines of code:
 
@@ -50,7 +50,7 @@ from blackjack import Game, Player
 # initiate Player object
 player = Player(100)
 # initiate Game object
-game = Game(1, [player])
+game = Game([player])
 
 # run simulation 1,000,000 times
 game.simulate(1000000)
@@ -70,7 +70,7 @@ from blackjack import Game, Player
 rules = {"blackjack_payout": 1.2}
 
 player = Player(100)
-game = Game(1, [player], rules)
+game = Game([player], rules)
 
 game.simulate(1000000)
 ```

--- a/blackjack/deck.py
+++ b/blackjack/deck.py
@@ -10,8 +10,6 @@ class Deck:
         """
         Initialize Deck class and create the first deck
         """
-        if not isinstance(decks, int):
-            raise TypeError("'deck' must be an integer.")
         self.deck = []
         self.decks = decks
         self.num_creates = 0

--- a/blackjack/game.py
+++ b/blackjack/game.py
@@ -2,6 +2,7 @@
 The Game class is used to handle all of the logistics of the game including
 dealing the cards, playing the players hands, and playing the dealer
 """
+import copy
 import os
 from .deck import Deck
 from .hand import Hand
@@ -20,7 +21,7 @@ class GameParams(Parameters):
 
 class Game:
 
-    def __init__(self, num_decks, players, rules=None, verbose=False):
+    def __init__(self, players, rules=None, verbose=False):
         """
         Parameters
         ----------
@@ -34,22 +35,23 @@ class Game:
             as the game progresses
         """
         # game parameters
-        self.num_decks = num_decks
-        self.deck = Deck(num_decks)
-        self.count = 0
-        self.ten_count = 16 * num_decks  # count of tens seen
-        self.other_count = 36 * num_decks  # count of non-tens seens
-        self.player_list = players
-        self.count = 0
-        self.num_players = len(players)
-        self.rules = rules
+        # make a copy of rules to avoid modifying the original dictionary
+        self.rules = copy.deepcopy(rules)
         self.game_params = GameParams(array_first=True)
         # update rules for the game
         if self.rules:
             if not isinstance(self.rules, dict):
                 raise TypeError("'rules' must be a dictionary.")
             self._update_params(self.rules)
-        assert 1 <= len(self.player_list) <= self.game_params.max_players
+        self.num_decks = self.game_params.num_decks
+        self.deck = Deck(self.num_decks)
+        self.count = 0
+        self.ten_count = 16 * self.num_decks  # count of tens seen
+        self.other_count = 36 * self.num_decks  # count of non-tens seens
+        self.player_list = players
+        self.count = 0
+        self.num_players = len(players)
+        assert 1 <= self.num_players <= self.game_params.max_players
         self.verbose = verbose
 
         # variables for data collection

--- a/blackjack/rules.json
+++ b/blackjack/rules.json
@@ -202,5 +202,21 @@
                 "choices": [true, false]
             }
         }
+    },
+    "num_decks": {
+        "title": "Number of decks the game will be played with",
+        "description": "Number of decks used in the game.",
+        "notes": "",
+        "section_1": "Game",
+        "section_2": "Deck",
+        "type": "int",
+        "number_dims": 0,
+        "value": [{"value": 8}],
+        "validators": {
+            "range": {
+                "min": 1,
+                "max": 9e+99
+            }
+        }
     }
 }

--- a/blackjack/tests/test_deck.py
+++ b/blackjack/tests/test_deck.py
@@ -6,8 +6,6 @@ from blackjack import Card, Deck
 
 
 def test_deck():
-    with pytest.raises(TypeError):
-        Deck("one")
     deck = Deck(3)
     assert len(deck) == 52 * 3
     while deck:

--- a/blackjack/tests/test_game.py
+++ b/blackjack/tests/test_game.py
@@ -7,22 +7,22 @@ from blackjack import Game, Player
 
 def test_game_implementation():
     with pytest.raises(TypeError):
-        Game(6, [Player(100)], "str")
+        Game([Player(100)], "str")
     # ensure that the parameters are updated properly
     rules = {"insurance_allowed": False,
              "blackjack_payout": 1.2}
-    game = Game(6, [Player(100)], rules)
+    game = Game([Player(100)], rules)
     assert game.game_params.blackjack_payout == 1.2
     assert not game.game_params.insurance_allowed
 
     # ensure player limits are imposed
     rules = {"max_players": 2}
     with pytest.raises(AssertionError):
-        Game(1, [Player(100), Player(100), Player(100)], rules)
+        Game([Player(100), Player(100), Player(100)], rules)
     with pytest.raises(AssertionError):
-        Game(1, [])
+        Game([])
 
 
 def test_simulation():
-    game = Game(1, [Player(100)])
+    game = Game([Player(100)])
     game.simulate(10)


### PR DESCRIPTION
This PR removes the `num_decks` argument from the `Game` class init function. Instead `num_decks` can be changed by modifying the rules of the game. This makes more sense logically because every other aspect of the game is modified this way.